### PR TITLE
Simplify Schema::title() with a cast; drop Schema::isTitle().

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -106,13 +106,8 @@ abstract class Schema
         return $this->type() === 'string';
     }
 
-    public function hasTitle(): bool
-    {
-        return isset($this->schema->title);
-    }
-
     public function title(): string
     {
-        return $this->hasTitle() ? $this->schema->title : '';
+        return (string) $this->schema->title;
     }
 }


### PR DESCRIPTION
This one might be a taste thing, but I was in there anyway... I usually default to less code unless it reduces readability. Here exchanging a ternary for a cast is a push, so I lean toward less code. Obviously, your call, no worries.