### PR TITLE
Add test for invalid type to SchemaTest.php.

### DIFF
--- a/src/Schema.php
+++ b/src/Schema.php
@@ -46,12 +46,10 @@ abstract class Schema
             return new Schema\StringSchema($json);
         }
 
-        // @codeCoverageIgnoreStart
         throw new \InvalidArgumentException(sprintf(
-            "No schema type available for %s",
+            "No schema type available for %s.",
             $json->type
         ));
-        // @codeCoverageIgnoreEnd
     }
 
     /**

--- a/test/SchemaTest.php
+++ b/test/SchemaTest.php
@@ -128,7 +128,7 @@ class SchemaTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('No schema type available for invalid.');
 
-        $schema = Schema::make($this->makeJsonObject([
+        Schema::make($this->makeJsonObject([
             'type' => 'invalid',
         ]));
     }

--- a/test/SchemaTest.php
+++ b/test/SchemaTest.php
@@ -123,6 +123,16 @@ class SchemaTest extends TestCase
         $this->assertSame('string', $schema->phpType());
     }
 
+    public function testInvalidType()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('No schema type available for invalid.');
+
+        $schema = Schema::make($this->makeJsonObject([
+            'type' => 'invalid',
+        ]));
+    }
+
     /**
      * @return object
      */


### PR DESCRIPTION
I got ambitious this evening.  Is this the sort of thing that you were looking for?

`testInvalidType()` is a bigger issue as you're not handling that case at all; I'm guessing introducing a guard clause checking that `$json->type` is set, throwing an exception if not, is the direction you'd want to go, unless I'm missing something. If so, let me know, I'll do that, too.